### PR TITLE
Issue #18

### DIFF
--- a/contracts/MasterAMO.sol
+++ b/contracts/MasterAMO.sol
@@ -90,6 +90,13 @@ abstract contract MasterAMO is
     mapping(address => bool) public override bypassSwapRatioWhitelist;
     EnumerableSet.AddressSet internal _bypassSwapRatioMembers;
 
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     */
+    uint256[50] private __gap;
+
     // -------------------------------------------------------------
     //                      INTERNAL CONSTANTS
     // -------------------------------------------------------------


### PR DESCRIPTION
A storage gap was added after the `MasterAMO` state variables to allow for future upgrades.
