### PR TITLE
Issues #19 #24 #25

### DIFF
--- a/contracts/V2AMO.sol
+++ b/contracts/V2AMO.sol
@@ -7,8 +7,6 @@ import {ISolidlyRouter} from "./interfaces/v2/ISolidlyRouter.sol";
 import {IPair} from "./interfaces/v2/IPair.sol";
 import {IV2AMO} from "./interfaces/IV2AMO.sol";
 import {IVRouter} from "./interfaces/v2/IVRouter.sol";
-import {IPoolFactory} from "./interfaces/v2/IPoolFactory.sol";
-import {IPairFactory} from "./interfaces/v2/IPairFactory.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
 import {IIon} from "./interfaces/IIon.sol";
@@ -73,11 +71,12 @@ contract V2AMO is IV2AMO, MasterAMO {
      * @param ionAddress_ Address of the ION token.
      * @param pairTokenAddress_ Address of the Pair token.
      * @param isStable_ True if the pool is stable; false if volatile.
-     * @param poolType_ The pool type (SOLIDLY_V2, VELO_LIKE or EQUAL_LIKE).
+     * @param poolType_ The pool type (SOLIDLY_V2 or VELO_LIKE).
+     * @param poolFee_ The pool fee in decimals 6.
      * @param ionMinterAddress_ Address of the ION minter contract.
      * @param priceManagerAddress_ Address of the price manager contract.
      * @param pairTokenType_ The type of the token paired with ION.
-     * @param factoryAddress_ Address of the factory (if zero, the default factory is used for VELO_LIKE pools).
+     * @param factoryAddress_ Address of the factory.
      * @param routerAddress_ Address of the router contract.
      * @param gaugeAddress_ Address of the gauge contract.
      * @param rewardVault_ Address of the reward vault.
@@ -93,6 +92,7 @@ contract V2AMO is IV2AMO, MasterAMO {
         address pairTokenAddress_,
         bool isStable_,
         PoolType poolType_,
+        uint256 poolFee_,
         address ionMinterAddress_,
         address priceManagerAddress_,
         PairTokenType pairTokenType_,
@@ -114,13 +114,10 @@ contract V2AMO is IV2AMO, MasterAMO {
         isStablePool = isStable_;
         factoryAddress = factoryAddress_;
         address pool_;
-        uint256 poolFee_;
         if (poolType == PoolType.VELO_LIKE) {
             pool_ = IVRouter(routerAddress_).poolFor(pairTokenAddress_, ionAddress_, isStable_, factoryAddress);
-            poolFee_ = IPoolFactory(factoryAddress).getFee(pool_, isStable_);
         } else {
             pool_ = ISolidlyRouter(routerAddress_).pairFor(pairTokenAddress_, ionAddress_, isStable_);
-            poolFee_ = IPairFactory(factoryAddress).getFee(isStable_);
         }
 
         // Initialize inherited variables from MasterAMO
@@ -139,9 +136,8 @@ contract V2AMO is IV2AMO, MasterAMO {
 
         routerAddress = routerAddress_;
         gaugeAddress = gaugeAddress_;
-        uint256 feeScaledFactor = poolType == PoolType.EQUAL_LIKE ? 1e18 : 1e4;
         _grantRole(SETTER_ROLE, msg.sender);
-        setPoolFee(poolFee_.mulDiv(SCALED_UNIT, feeScaledFactor));
+        setPoolFee(poolFee_);
         setVault(rewardVault_);
         setTokenId(tokenId_, useTokenId_);
         _revokeRole(SETTER_ROLE, msg.sender);

--- a/contracts/interfaces/IV2AMO.sol
+++ b/contracts/interfaces/IV2AMO.sol
@@ -78,8 +78,7 @@ interface IV2AMO {
      */
     enum PoolType {
         SOLIDLY_V2,
-        VELO_LIKE, // Aerodrome, Velodrome
-        EQUAL_LIKE // Equalizer (EQUAL on Sonic, SCALE on Base)
+        VELO_LIKE // Aerodrome, Velodrome
     }
 
     // -------------------------------------------------------------

--- a/contracts/interfaces/v2/IPairFactory.sol
+++ b/contracts/interfaces/v2/IPairFactory.sol
@@ -5,4 +5,8 @@ interface IPairFactory {
     function createPair(address tokenA, address tokenB, bool stable) external returns (address pair);
 
     function getFee(bool) external view returns (uint256);
+
+    function stableFees() external view returns (uint256);
+
+    function volatileFees() external view returns (uint256);
 }

--- a/test/amo/equalizer_v2.test.ts
+++ b/test/amo/equalizer_v2.test.ts
@@ -65,14 +65,15 @@ describe("EQUALIZER", function () {
                 admin,
                 await ion.getAddress(),
                 await pairToken.getAddress(),
-                V2PoolType.EQUAL_LIKE,
+                V2PoolType.SOLIDLY_V2,
                 await minter.getAddress(),
                 await priceManager.getAddress(),
                 pairedTokenType,
                 V2_ROUTER,
                 validRangeWidth,
                 sellRatio,
-                buyRatio
+                buyRatio,
+                BigInt(10 ** 18)
               );
               const amoAddress = await v2amo.getAddress();
               const AMO_ROLE = await minter.AMO_ROLE();

--- a/test/amo/solidly_v2.test.ts
+++ b/test/amo/solidly_v2.test.ts
@@ -1,0 +1,125 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+import { Ion, Minter, MockERC20, PriceManager, V2AMO } from "../../typechain-types";
+import {
+  addV2Liquidity,
+  deployBaseContracts,
+  deployV2AMO,
+  getCurrentPrice,
+  getInitPrice,
+  getTestCaseTitle,
+  initNetwork,
+  logPriceDiff,
+  PairTokenType,
+  pairedTokenTypeName,
+  V2PoolType,
+  v2Swap
+} from "./utils";
+
+describe("SOLIDLY V2", function () {
+  const rpcUrl = "https://eth-mainnet.public.blastapi.io";
+  const forkingBlock = 22274000;
+  const swapAmounts = ["900000"];
+  const LOG_PRICES = false;
+  const initAmount = "11000000"; // 11M
+  const lpAmount = "1000000"; // 1M
+  const delta = ethers.parseUnits("0.00001", 6);
+  const pairTokenTypesToTest = [PairTokenType.SUSDE, PairTokenType.STABLE];
+  const pairTokenDecimalsToTest = [6, 18];
+
+  // AMO consts
+  const validRangeWidth = ethers.parseUnits("0.01", 6);
+  const sellRatio = ethers.parseUnits("1", 6);
+  const buyRatio = ethers.parseUnits("1", 6);
+
+  // V2 consts
+  const V2_ROUTER = "0x77784f96C936042A3ADB1dD29C91a55EB2A4219f"; // BaseV2Router01
+
+  let admin: SignerWithAddress;
+  let user: SignerWithAddress;
+
+  let ion: Ion;
+  let pairToken: MockERC20;
+  let minter: Minter;
+  let priceManager: PriceManager;
+  let v2amo: V2AMO;
+
+  for (const pairedTokenType of pairTokenTypesToTest) {
+    describe(`Paired token type: ${pairedTokenTypeName(pairedTokenType)}`, function () {
+      for (const pairTokenDecimals of pairTokenDecimalsToTest) {
+        describe(`Pair token decimals: ${pairTokenDecimals}`, function () {
+          describe("V2AMO", function () {
+            before(async () => {
+              [admin, user, priceManager] = await initNetwork(rpcUrl, forkingBlock);
+              console.log(
+                `\t\t\t\t\tNetwork init for V2AMO ${pairedTokenTypeName(pairedTokenType)}\t${pairTokenDecimals}`
+              );
+            });
+            beforeEach(async function () {
+              [ion, pairToken, minter] = await deployBaseContracts(admin, user, pairTokenDecimals, initAmount);
+
+              const initPrice = await getInitPrice(priceManager, pairedTokenType);
+
+              v2amo = await deployV2AMO(
+                admin,
+                await ion.getAddress(),
+                await pairToken.getAddress(),
+                V2PoolType.SOLIDLY_V2,
+                await minter.getAddress(),
+                await priceManager.getAddress(),
+                pairedTokenType,
+                V2_ROUTER,
+                validRangeWidth,
+                sellRatio,
+                buyRatio,
+                BigInt(10 ** 6),
+                true
+              );
+              const amoAddress = await v2amo.getAddress();
+              const AMO_ROLE = await minter.AMO_ROLE();
+              await minter.connect(admin).grantRole(AMO_ROLE, amoAddress);
+              await addV2Liquidity(admin, V2_ROUTER, ion, pairToken, amoAddress, lpAmount, initPrice);
+            });
+
+            describe("V2 Public mintSellFarm", () => {
+              for (const swapAmount of swapAmounts) {
+                it(getTestCaseTitle(swapAmount), async function () {
+                  await v2Swap(user, pairToken, ion, V2_ROUTER, swapAmount);
+                  const { tp, cp } = await logPriceDiff(v2amo);
+                  if (Number(swapAmount) > 0) {
+                    await v2amo.mintSellFarm();
+                    const newPrice = await getCurrentPrice(v2amo, LOG_PRICES);
+                    expect(newPrice).to.be.approximately(tp, delta);
+                  } else {
+                    await expect(v2amo.mintSellFarm())
+                      .to.be.revertedWithCustomError(v2amo, "PriceAlreadyInRange")
+                      .withArgs(cp, tp);
+                  }
+                });
+              }
+            });
+
+            describe("V2 Public unfarmBuyBurn", () => {
+              for (const swapAmount of swapAmounts) {
+                it(getTestCaseTitle(swapAmount, false), async function () {
+                  await v2Swap(user, ion, pairToken, V2_ROUTER, swapAmount);
+                  const { tp, cp } = await logPriceDiff(v2amo);
+                  if (Number(swapAmount) > 0) {
+                    await v2amo.unfarmBuyBurn();
+                    const newPrice = await getCurrentPrice(v2amo, LOG_PRICES);
+                    expect(newPrice).to.be.approximately(tp, delta);
+                  } else {
+                    await expect(v2amo.unfarmBuyBurn())
+                      .to.be.revertedWithCustomError(v2amo, "PriceAlreadyInRange")
+                      .withArgs(cp, tp);
+                  }
+                });
+              }
+            });
+          });
+        });
+      }
+    });
+  }
+});

--- a/test/amo/utils.ts
+++ b/test/amo/utils.ts
@@ -85,8 +85,7 @@ export enum V3PoolType {
 
 export enum V2PoolType {
   SOLIDLY_V2,
-  VELO_LIKE, // Aerodrome, Velodrome
-  EQUAL_LIKE // Equalizer (EQUAL on Sonic, SCALE on Base)
+  VELO_LIKE // Aerodrome, Velodrome
 }
 
 export async function initNetwork(
@@ -248,31 +247,39 @@ export async function deployV2AMO(
   routerAddress: string,
   validRangeWidth: bigint,
   sellRatio: bigint,
-  buyRatio: bigint
+  buyRatio: bigint,
+  feeDivider: bigint = BigInt(10 ** 4)
 ): Promise<V2AMO> {
   const GaugeFactory = await ethers.getContractFactory("MockGauge");
   const gauge = await GaugeFactory.deploy();
   await gauge.waitForDeployment();
   const gaugeAddress = await gauge.getAddress();
   const stable = false;
-  let factoryAddress;
-  if ([V2PoolType.SOLIDLY_V2, V2PoolType.EQUAL_LIKE].includes(poolType)) {
+  let factoryAddress: string;
+  let poolFee: bigint;
+  if (poolType === V2PoolType.SOLIDLY_V2) {
     const router = await ethers.getContractAt("ISolidlyRouter", routerAddress);
     factoryAddress = await router.factory();
+    const factory = await ethers.getContractAt("IPairFactory", factoryAddress);
     if ((await router.pairFor(ionAddress, pairTokenAddress, stable)) === ethers.ZeroAddress) {
-      const factory = await ethers.getContractAt("IPairFactory", factoryAddress);
       await factory.createPair(ionAddress, pairTokenAddress, stable);
     }
+    poolFee = await factory.getFee(stable);
   } else {
     const router = await ethers.getContractAt("IVRouter", routerAddress);
     factoryAddress = await router.defaultFactory();
+    const poolAddress = await router.poolFor(pairTokenAddress, ionAddress, stable, factoryAddress);
+    const factory = await ethers.getContractAt("IPoolFactory", factoryAddress);
+    poolFee = await factory.getFee(poolAddress, stable);
   }
+  poolFee = (poolFee * BigInt(10 ** 6)) / feeDivider; // scaled to decimals 6
   const args = [
     admin.address,
     ionAddress,
     pairTokenAddress,
     stable,
     poolType,
+    poolFee,
     minterAddress,
     priceManagerAddress,
     pairedTokenType,

--- a/test/amo/utils.ts
+++ b/test/amo/utils.ts
@@ -248,7 +248,8 @@ export async function deployV2AMO(
   validRangeWidth: bigint,
   sellRatio: bigint,
   buyRatio: bigint,
-  feeDivider: bigint = BigInt(10 ** 4)
+  feeDivider: bigint = BigInt(10 ** 4),
+  isSolidly: boolean = false
 ): Promise<V2AMO> {
   const GaugeFactory = await ethers.getContractFactory("MockGauge");
   const gauge = await GaugeFactory.deploy();
@@ -264,7 +265,12 @@ export async function deployV2AMO(
     if ((await router.pairFor(ionAddress, pairTokenAddress, stable)) === ethers.ZeroAddress) {
       await factory.createPair(ionAddress, pairTokenAddress, stable);
     }
-    poolFee = await factory.getFee(stable);
+    if (isSolidly) {
+      const factory = await ethers.getContractAt("IPairFactory", factoryAddress);
+      poolFee = stable ? await factory.stableFees() : await factory.volatileFees();
+    } else {
+      poolFee = await factory.getFee(stable);
+    }
   } else {
     const router = await ethers.getContractAt("IVRouter", routerAddress);
     factoryAddress = await router.defaultFactory();


### PR DESCRIPTION
Since each DEX has a different method for retrieving pool fees and uses varying decimal formats, we decided to make the pool fee an input parameter for the `initialize` function. This approach avoids relying on multiple if-else statements and also enabled us to remove the `EQUAL_LIKE` pool type.
