### PR TITLE
Issue #20

### DIFF
--- a/contracts/MasterAMO.sol
+++ b/contracts/MasterAMO.sol
@@ -306,6 +306,28 @@ abstract contract MasterAMO is
         return price + price.mulDiv(validRangeWidth, SCALED_UNIT);
     }
 
+    /**
+     * @notice Calculates a limited adjusted target price for a sell based on the given sell ratio.
+     * @param _sellRatio The ratio to scale the price delta.
+     * @return The adjusted price resulting from applying the scaled delta to the target price.
+     */
+    function limitedTargetPriceForSell(uint24 _sellRatio) internal view returns (uint256) {
+        uint256 targetPrice = ionTargetPriceInPairToken();
+        uint256 priceDelta = ionPriceInPairToken() - targetPrice;
+        return targetPrice + priceDelta.mulDiv((SCALED_UNIT - _sellRatio), SCALED_UNIT);
+    }
+
+    /**
+     * @notice Calculates a limited adjusted target price for a buy based on the given buy ratio.
+     * @param _buyRatio The ratio to scale the price delta.
+     * @return The adjusted price resulting from subtracting the scaled delta from the target price.
+     */
+    function limitedTargetPriceForBuy(uint24 _buyRatio) internal view returns (uint256) {
+        uint256 targetPrice = ionTargetPriceInPairToken();
+        uint256 priceDelta = targetPrice - ionPriceInPairToken();
+        return targetPrice - priceDelta.mulDiv((SCALED_UNIT - _buyRatio), SCALED_UNIT);
+    }
+
     /// @notice Internal function to validate mintSellFarm.
     function _validateSell() internal view virtual {
         uint256 currentPrice = ionPriceInPairToken();

--- a/contracts/V2AMO.sol
+++ b/contracts/V2AMO.sol
@@ -189,9 +189,7 @@ contract V2AMO is IV2AMO, MasterAMO {
     function _mintAndSell(uint24 swapRatio) internal override returns (uint256 postOperationIonPrice) {
         // Calculating ION amount for mint and sell
         (uint256 ionReserve, uint256 pairTokenReserve) = getReserves();
-        uint256 targetPrice = ionTargetPriceInPairToken();
-        uint256 priceDelta = ionPriceInPairToken() - targetPrice;
-        targetPrice += priceDelta.mulDiv((SCALED_UNIT - swapRatio), SCALED_UNIT);
+        uint256 targetPrice = limitedTargetPriceForSell(swapRatio);
         uint256 ionAmountWithoutFee = Math.sqrt((pairTokenReserve * ionReserve * SCALED_UNIT) / targetPrice) -
             ionReserve;
         uint256 ionAmount = ionAmountWithoutFee.mulDiv(SCALED_UNIT, (SCALED_UNIT - poolFee));
@@ -356,9 +354,7 @@ contract V2AMO is IV2AMO, MasterAMO {
     function _calculateLiquidityToUnfarm(uint24 swapRatio) internal view returns (uint256 liquidity) {
         (uint256 ionReserve, uint256 pairTokenReserve) = getReserves();
         uint256 totalLp = IERC20(poolAddress).totalSupply();
-        uint256 targetPrice = ionTargetPriceInPairToken();
-        uint256 priceDelta = targetPrice - ionPriceInPairToken();
-        targetPrice -= priceDelta.mulDiv((SCALED_UNIT - swapRatio), SCALED_UNIT);
+        uint256 targetPrice = limitedTargetPriceForBuy(swapRatio);
         uint256 sqrtResRatio = Math.sqrt(
             (SCALED_UNIT ** 2 * pairTokenReserve) / ((ionReserve * targetPrice) / SCALED_UNIT)
         );

--- a/contracts/V2AMO.sol
+++ b/contracts/V2AMO.sol
@@ -190,8 +190,10 @@ contract V2AMO is IV2AMO, MasterAMO {
         // Calculating ION amount for mint and sell
         (uint256 ionReserve, uint256 pairTokenReserve) = getReserves();
         uint256 targetPrice = ionTargetPriceInPairToken();
-        uint256 ionAmountWithoutFee = ((Math.sqrt((pairTokenReserve * ionReserve * SCALED_UNIT) / targetPrice) -
-            ionReserve) * swapRatio) / SCALED_UNIT;
+        uint256 priceDelta = ionPriceInPairToken() - targetPrice;
+        targetPrice += priceDelta.mulDiv((SCALED_UNIT - swapRatio), SCALED_UNIT);
+        uint256 ionAmountWithoutFee = Math.sqrt((pairTokenReserve * ionReserve * SCALED_UNIT) / targetPrice) -
+            ionReserve;
         uint256 ionAmount = ionAmountWithoutFee.mulDiv(SCALED_UNIT, (SCALED_UNIT - poolFee));
 
         // Mint ION tokens to this contract
@@ -351,11 +353,14 @@ contract V2AMO is IV2AMO, MasterAMO {
         pairTokenCollectedFee = 0;
     }
 
-    function _calculateLiquidityToUnfarm() internal view returns (uint256 liquidity) {
+    function _calculateLiquidityToUnfarm(uint24 swapRatio) internal view returns (uint256 liquidity) {
         (uint256 ionReserve, uint256 pairTokenReserve) = getReserves();
         uint256 totalLp = IERC20(poolAddress).totalSupply();
+        uint256 targetPrice = ionTargetPriceInPairToken();
+        uint256 priceDelta = targetPrice - ionPriceInPairToken();
+        targetPrice -= priceDelta.mulDiv((SCALED_UNIT - swapRatio), SCALED_UNIT);
         uint256 sqrtResRatio = Math.sqrt(
-            (SCALED_UNIT ** 2 * pairTokenReserve) / ((ionReserve * ionTargetPriceInPairToken()) / SCALED_UNIT)
+            (SCALED_UNIT ** 2 * pairTokenReserve) / ((ionReserve * targetPrice) / SCALED_UNIT)
         );
         uint256 removalPercentage = (SCALED_UNIT * (SCALED_UNIT - sqrtResRatio)) /
             (SCALED_UNIT - ((poolFee * sqrtResRatio) / SCALED_UNIT));
@@ -366,8 +371,7 @@ contract V2AMO is IV2AMO, MasterAMO {
     function _unfarmBuyBurn(
         uint24 swapRatio
     ) internal override returns (uint256 liquidity, uint256 postOperationIonPrice) {
-        liquidity = _calculateLiquidityToUnfarm();
-        liquidity = liquidity.mulDiv(swapRatio, SCALED_UNIT);
+        liquidity = _calculateLiquidityToUnfarm(swapRatio);
         (uint256 ionRemoved, uint256 pairTokenRemoved, , ) = _removeLiquidity(liquidity);
 
         // Approve router for the PairToken swap.

--- a/contracts/V3AMO.sol
+++ b/contracts/V3AMO.sol
@@ -258,9 +258,7 @@ contract V3AMO is IV3AMO, MasterAMO {
 
     /// @inheritdoc MasterAMO
     function _mintAndSell(uint24 swapRatio) internal override returns (uint256 postOperationIonPrice) {
-        uint256 targetPrice = ionTargetPriceInPairToken();
-        uint256 priceDelta = ionPriceInPairToken() - targetPrice;
-        targetPrice += priceDelta.mulDiv((SCALED_UNIT - swapRatio), SCALED_UNIT);
+        uint256 targetPrice = limitedTargetPriceForSell(swapRatio);
         (int256 amount0, int256 amount1) = IUniswapV3Pool(poolAddress).swap(
             address(this),
             ionAddress < pairTokenAddress, // zeroForOne
@@ -355,9 +353,7 @@ contract V3AMO is IV3AMO, MasterAMO {
         uint24 swapRatio
     ) internal returns (uint256 liquidity, uint160 sqrtPriceLimitX96) {
         uint256 positionLiquidity = getLiquidity();
-        uint256 targetPrice = ionTargetPriceInPairToken();
-        uint256 priceDelta = targetPrice - ionPriceInPairToken();
-        targetPrice -= priceDelta.mulDiv((SCALED_UNIT - swapRatio), SCALED_UNIT);
+        uint256 targetPrice = limitedTargetPriceForBuy(swapRatio);
         sqrtPriceLimitX96 = toSqrtPriceX96(targetPrice);
         try
             IUniswapV3Pool(poolAddress).swap(


### PR DESCRIPTION
Two functions were added to calculate a limited adjusted target price based on the swap ratio, and are used in both `V2AMO` and `V3AMO` to resolve the inconsistent usage issue.
